### PR TITLE
TRITON-2115 CloudAPI /:account/machines/:machine/vnc endpoint limiting itself to KVM instances

### DIFF
--- a/lib/endpoints/vnc.js
+++ b/lib/endpoints/vnc.js
@@ -38,7 +38,7 @@ function mount(server, before, pre) {
 
 function connectVNC(req, res, next) {
     var vm = req.machine;
-    if (vm.brand !== 'kvm') {
+    if (vm.brand !== 'kvm' && vm.brand !== 'bhyve') {
         res.send(400, new restify.RestError({
             statusCode: 400,
             restCode: 'MachineHasNoVNC',


### PR DESCRIPTION
Noticed this earlier.. should fix this prior to the release...