### PR TITLE
TRITON-2152 Add support for AccessKeys

### DIFF
--- a/lib/app.js
+++ b/lib/app.js
@@ -20,7 +20,6 @@ var assert = require('assert-plus');
 var fs = require('fs');
 var http = require('http');
 var https = require('https');
-var util = require('util');
 var path = require('path');
 
 var createMetricsManager = require('triton-metrics').createMetricsManager;
@@ -58,6 +57,7 @@ var auditLogger = require('./audit_logger');
 var rules = require('./rules');
 var volumeEndpoints = require('./endpoints/volumes');
 var vnc = require('./endpoints/vnc');
+var accessKeysEndpoints = require('./endpoints/accesskeys');
 
 // Account users, roles and policies:
 var users = require('./users');
@@ -71,7 +71,7 @@ var APERTURE_CFG = path.join(__dirname, '..', '/etc/aperture.json');
 var apertureConfig = {};
 try {
     apertureConfig = JSON.parse(fs.readFileSync(APERTURE_CFG, 'utf8'));
-} catch (e) {
+} catch (_e) {
     apertureConfig = {
         typeTable: {
             ip: 'ip',
@@ -88,17 +88,8 @@ var PluginManager = require('./plugin-manager');
 
 // --- Globals
 
-var HTML_FMT = '<html><head /><body><p>%s</p></body></html>\n';
 var VERSION = false;
-var sprintf = util.format;
-
 var userThrottle = throttle.getUserThrottle;
-var ipThrottle = throttle.getIpThrottle;
-var emptyThrottle = throttle.getEmptyThrottle;
-
-var MORAY_POLL = 5000; // in ms
-
-
 
 // --- Internal functions
 
@@ -191,14 +182,14 @@ function createClients(options, callback) {
         agent = new cueball.HttpAgent(options.cueballHttpAgent);
     }
 
-    options.ufds.log   = options.log.child({ component: 'ufds' });
+    options.ufds.log = options.log.child({ component: 'ufds' });
     options.ufds_master.log = options.log.child({ component: 'ufds_master' });
-    options.vmapi.log  = options.log.child({ component: 'vmapi' });
-    options.napi.log   = options.log.child({ component: 'napi' });
+    options.vmapi.log = options.log.child({ component: 'vmapi' });
+    options.napi.log = options.log.child({ component: 'napi' });
     options.imgapi.log = options.log.child({ component: 'imgapi' });
-    options.papi.log   = options.log.child({ component: 'papi' });
-    options.fwapi.log  = options.log.child({ component: 'fwapi' });
-    options.cnapi.log  = options.log.child({ component: 'cnapi' });
+    options.papi.log = options.log.child({ component: 'papi' });
+    options.fwapi.log = options.log.child({ component: 'fwapi' });
+    options.cnapi.log = options.log.child({ component: 'cnapi' });
 
     options.fwapi.agent = agent;
     options.cnapi.agent = agent;
@@ -265,7 +256,6 @@ function createClients(options, callback) {
 module.exports = {
 
     createServer: function (config, callback) {
-
         var log = config.log;
         var globalAgentInterval;
         var server;
@@ -481,7 +471,6 @@ module.exports = {
 
                 if ((mthd === 'PUT' || mthd === 'POST' || mthd === 'DELETE') &&
                     req.config.read_only === true) {
-
                     if (req.config.dcMaintUtcEta) {
                         res.setHeader('Retry-After', req.config.dcMaintUtcEta);
                     }
@@ -566,6 +555,9 @@ module.exports = {
                 volumeEndpoints.mount(server, userThrottle(config, 'volumes'));
             }
 
+            accessKeysEndpoints.mount(server,
+                userThrottle(config, 'accesskeys'), config);
+
             server.on('after', auditLogger({
                 log: log.child({component: 'audit'})
             }));
@@ -645,7 +637,7 @@ module.exports = {
                 });
             });
 
-            server.on('uncaughtException', function (req, res, route, err) {
+            server.on('uncaughtException', function (req, res, _route, err) {
                 var e = new restify.InternalError('Internal Error');
                 req.log.error(err, 'unexpected error');
                 res.send(e);

--- a/lib/endpoints/accesskeys.js
+++ b/lib/endpoints/accesskeys.js
@@ -1,0 +1,300 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+/*
+ * Copyright 2020 Joyent, Inc.
+ */
+
+
+var util = require('util');
+
+var assert = require('assert-plus');
+var jsprim = require('jsprim');
+var restify = require('restify');
+
+var resources = require('../resources');
+
+
+var sprintf = util.format;
+
+var InvalidArgumentError = restify.InvalidArgumentError;
+
+function translateAccessKey(accesskey) {
+    if (!accesskey) {
+        return {};
+    }
+
+    var obj = jsprim.deepCopy(accesskey);
+    obj.created = new Date(Number(accesskey.created)).toISOString();
+
+    obj.status = 'Active';
+
+    return obj;
+}
+
+
+function create(req, res, next) {
+    var log = req.log;
+    var login = req.account.login;
+    var ufds = req.sdc.ufds_master;
+
+    var user, account;
+    if (req.params.user) {
+        user = req.params.user;
+        account = req.account.uuid;
+    } else {
+        user = req.account;
+        account = '';
+    }
+
+    try {
+        ufds.addAccessKey(user, account, function (err, accesskey) {
+            if (err) {
+                if (err.statusCode === 404) {
+                    next(err);
+                    return;
+                }
+
+                log.error({err: err}, 'Create access key error');
+
+                var msg = 'key is invalid';
+                next(new InvalidArgumentError(msg));
+                return;
+            }
+
+            accesskey = translateAccessKey(accesskey);
+
+            if (account) {
+                res.header('Location',
+                    sprintf('/%s/users/%s/accesskeys/%s',
+                        login,
+                        user,
+                        encodeURIComponent(accesskey.accesskeyid)));
+            } else {
+                res.header('Location',
+                    sprintf('/%s/accesskeys/%s',
+                        login,
+                        encodeURIComponent(accesskey.accesskeyid)));
+            }
+
+            if (req.headers['role-tag'] || req.activeRoles) {
+                // The resource we want to save is the individual one we've
+                // just created, not the collection URI:
+                req.resourcename = req.resourcename + '/' +
+                    accesskey.accesskeyid;
+                req.resource = {
+                    name: req.resourcename,
+                    account: req.account.uuid,
+                    roles: []
+                };
+            }
+
+            log.debug('POST %s => %j', req.path(), accesskey);
+            res.send(201, accesskey);
+            next();
+            return;
+        });
+    } catch (e) {
+        log.error({err: e}, 'Create accesskey exception');
+        next(new InvalidArgumentError('accesskey is invalid'));
+        return;
+    }
+}
+
+
+function list(req, res, next) {
+    var log = req.log;
+    var ufds = req.sdc.ufds_master;
+    var noCache = req.params.sync;
+    var user, account;
+    if (req.params.user) {
+        user = req.params.user;
+        account = req.account.uuid;
+    } else {
+        user = req.account;
+        account = '';
+    }
+
+    if (req.accountMgmt) {
+        resources.getRoleTags(req, res);
+    }
+
+    function _mapAccessKeys(accessKeys) {
+        accessKeys = accessKeys.map(translateAccessKey);
+        log.debug('GET %s => %j', req.path(), accessKeys);
+        res.send(accessKeys);
+        next();
+    }
+
+    ufds.listAccessKeys(user, account,
+        function _listAccessKeysCb(err, accesskeys) {
+        if (err) {
+            if (req.sdc.is_ufds_master) {
+                next(err);
+                return;
+            }
+            // Fallback to local UFDS instance instead of ufds_master just
+            // in case master is down:
+            req.sdc.ufds.listAccessKeys(user, account,
+                function _listLocalAccessKeysCb(err2, accesskeys2) {
+                if (err2) {
+                    next(err2);
+                    return;
+                }
+                _mapAccessKeys(accesskeys2);
+                return;
+            });
+        }
+
+        _mapAccessKeys(accesskeys);
+    }, noCache);
+}
+
+
+function get(req, res, next) {
+    var log = req.log;
+    var ufds = req.sdc.ufds_master;
+    var noCache = req.params.sync;
+    var user, account;
+    if (req.params.user) {
+        user = req.params.user;
+        account = req.account.uuid;
+    } else {
+        user = req.account;
+        account = '';
+    }
+
+    if (req.accountMgmt) {
+        resources.getRoleTags(req, res);
+    }
+
+    ufds.getAccessKey(user, req.params.accesskeyid, account,
+        function _getAccessKeyCb(err, accesskey) {
+        if (err) {
+            next(err);
+            return;
+        }
+
+        accesskey = translateAccessKey(accesskey);
+        log.debug('GET %s => %j', req.path(), accesskey);
+        res.send(accesskey);
+        next();
+        return;
+    }, noCache);
+}
+
+function del(req, res, next) {
+    var log = req.log;
+    var ufds = req.sdc.ufds_master;
+    var user, account;
+    if (req.params.user) {
+        user = req.params.user;
+        account = req.account.uuid;
+    } else {
+        user = req.account;
+        account = '';
+    }
+
+    ufds.deleteAccessKey(user, req.params.accesskeyid, account, function (err) {
+        if (err) {
+            next(err);
+            return;
+        }
+
+        log.debug('DELETE %s -> ok', req.path());
+        res.send(204);
+        next();
+    });
+}
+
+
+function mount(server, before, config) {
+    assert.object(server);
+    assert.ok(before);
+    assert.ok(config);
+
+    server.post({
+        path: '/:account/accesskeys',
+        name: 'CreateAccessKey',
+        contentType: [
+            'multipart/form-data',
+            'application/octet-stream',
+            'application/json',
+            'text/plain'
+        ]
+    }, before, create, resources.updateResource);
+
+    server.get({
+        path: '/:account/accesskeys',
+        name: 'ListAccessKeys'
+    }, before, list);
+
+    server.head({
+        path: '/:account/accesskeys',
+        name: 'HeadAccessKeys'
+    }, before, list);
+
+    server.get({
+        path: '/:account/accesskeys/:accesskeyid',
+        name: 'GetAccessKey'
+    }, before, get);
+
+    server.head({
+        path: '/:account/accesskeys/:accesskeyid',
+        name: 'HeadAccessKey'
+    }, before, get);
+
+    server.del({
+        path: '/:account/accesskeys/:accesskeyid',
+        name: 'DeleteAccessKey'
+    }, before, del, resources.deleteResource);
+
+
+    // Account sub users ssh keys end-points:
+    server.post({
+        path: '/:account/users/:user/accesskeys',
+        name: 'CreateUserAccessKey',
+        contentType: [
+            'multipart/form-data',
+            'application/octet-stream',
+            'application/json',
+            'text/plain'
+        ]
+    }, before, create,
+    resources.updateResource);
+
+    server.get({
+        path: '/:account/users/:user/accesskeys',
+        name: 'ListUserAccessKeys'
+    }, before, list);
+
+    server.head({
+        path: '/:account/users/:user/accesskeys',
+        name: 'HeadUserAccessKeys'
+    }, before, list);
+
+    server.get({
+        path: '/:account/users/:user/accesskeys/:accesskeyid',
+        name: 'GetUserAccessKey'
+    }, before, get);
+
+    server.head({
+        path: '/:account/users/:user/accesskeys/:accesskeyid',
+        name: 'HeadUserAccessKey'
+    }, before, get);
+
+    server.del({
+        path: '/:account/users/:user/accesskeys/:accesskeyid',
+        name: 'DeleteUserAccessKey'
+    }, before, del, resources.deleteResource);
+
+    return server;
+}
+
+
+module.exports = {
+    mount: mount
+};

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "cloudapi",
     "description": "Triton CloudAPI",
-    "version": "9.10.0",
+    "version": "9.11.0",
     "author": "Joyent (joyent.com)",
     "private": true,
     "engines": {
@@ -31,7 +31,7 @@
         "krill": "1.0.1",
         "libuuid": "0.2.1",
         "mahi": "2.3.0",
-        "mime": "1.2.7",
+        "mime": "^1.4.1",
         "mooremachine": "^2.2.0",
         "nodemailer": "0.7.1",
         "nopt": "2.0.0",
@@ -40,7 +40,7 @@
         "semver": "5.4.1",
         "triton-metrics": "0.1.0",
         "triton-netconfig": "1.3.0",
-        "ufds": "1.6.0",
+        "ufds": "1.7.0",
         "uuid-by-string": "0.6.0",
         "vasync": "2.2.0",
         "verror": "1.10.0",
@@ -49,7 +49,7 @@
     "devDependencies": {
         "@smaller/tap": "11.1.4-1.0.0",
         "smartdc": "8.1.0",
-        "sshpk": "1.13.1"
+        "sshpk": "^1.16.1"
     },
     "sdcDependencies": {
         "imgapi": ">=2.1.0",

--- a/test/accesskeys.test.js
+++ b/test/accesskeys.test.js
@@ -1,0 +1,127 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+/*
+ * Copyright 2020 Joyent, Inc.
+ */
+
+
+const test = require('@smaller/tap').test;
+
+const common = require('./common');
+
+var CLIENTS;
+var CLIENT;
+var OTHER;
+var SERVER;
+var ACCESS_KEY;
+
+
+test('setup', function (t) {
+    common.setup(function (_, clients, server) {
+        CLIENTS = clients;
+        CLIENT = clients.user;
+        OTHER = clients.other;
+        SERVER = server;
+
+        t.end();
+    });
+});
+
+
+test('ListAccessKeys (empty) OK', function (t) {
+    CLIENT.get('/my/accesskeys', function (err, req, res, body) {
+        t.ifError(err);
+        t.equal(res.statusCode, 200);
+        common.checkHeaders(t, res.headers);
+        t.ok(body);
+        t.ok(Array.isArray(body));
+        t.equal(body.length, 0);
+        t.end();
+    });
+});
+
+
+test('CreateAccessKey OK', function (t) {
+    CLIENT.post('/my/accesskeys', {}, function (err, req, res, createdKey) {
+        t.ifError(err);
+        t.ok(createdKey);
+        t.equal(res.statusCode, 201);
+        common.checkHeaders(t, res.headers);
+        t.ok(createdKey.accesskeyid, 'accesskeyid');
+        t.ok(createdKey.accesskeysecret, 'accesskeysecret');
+        t.ok(createdKey.created, 'access key created');
+        t.equal(createdKey.status, 'Active');
+        ACCESS_KEY = createdKey;
+
+        CLIENT.get('/my/accesskeys', function (err2, req2, res2, body2) {
+            t.ifError(err2);
+            t.equal(res2.statusCode, 200);
+            common.checkHeaders(t, res2.headers);
+            t.ok(body2);
+            t.ok(body2.length);
+            var key_present = false;
+            body2.forEach(function (k) {
+                if (k.accesskeyid === createdKey.accesskeyid) {
+                    key_present = true;
+                }
+            });
+            t.ok(key_present);
+            t.end();
+        });
+    });
+});
+
+
+test('GetKey OK - other', function (t) {
+    var url = '/my/accesskeys/' + ACCESS_KEY.accesskeyid;
+
+    OTHER.get(url, function (err, req, res, body) {
+        t.ok(err);
+        t.ok(body);
+
+        t.equal(err.restCode, 'ResourceNotFound');
+        t.ok(err.message);
+
+        t.equal(body.code, 'ResourceNotFound');
+        t.ok(body.message);
+
+        t.equal(res.statusCode, 404);
+
+        t.end();
+    });
+});
+
+
+test('DeleteAccessKey OK', function (t) {
+    var url = '/my/accesskeys/' + ACCESS_KEY.accesskeyid;
+
+    CLIENT.del(url, function (err, req, res) {
+        t.ifError(err);
+        t.equal(res.statusCode, 204);
+        common.checkHeaders(t, res.headers);
+        t.end();
+    });
+});
+
+
+test('DeleteAccessKey 404', function (t) {
+    CLIENT.del('/my/accesskeys/' + common.uuid(), function (err) {
+        t.ok(err);
+        t.equal(err.statusCode, 404);
+        t.equal(err.restCode, 'ResourceNotFound');
+        t.ok(err.message);
+        t.end();
+    });
+});
+
+
+test('teardown', function (t) {
+    common.teardown(CLIENTS, SERVER, function (err) {
+        t.ifError(err, 'teardown success');
+        t.end();
+    });
+});


### PR DESCRIPTION
Tests passing so far:

```
[root@686d44d6-1725-474c-bf45-06416c54ed03 (coal:cloudapi0) /opt/smartdc/cloudapi]# ./test/runtests -f test/accesskeys.test.js
/opt/smartdc/cloudapi
# Setup a clean output dir (/var/tmp/cloudapitest).
# Running filtered set of test files: test/accesskeys.test.js
TAP version 13
# Subtest: setup
    1..0
ok 1 - setup # time=6177.316ms

# Subtest: ListAccessKeys (empty) OK
    ok 1 - should not error
    ok 2 - should be equal
    ok 3 - headers ok
    ok 4 - headers allow-origin
    ok 5 - headers allow-methods
    ok 6 - headers date
    ok 7 - headers request-id
    ok 8 - headers response time
    ok 9 - headers server
    ok 10 - headers connection
    ok 11 - headers api-version OK
    ok 12 - expect truthy value
    ok 13 - expect truthy value
    ok 14 - should be equal
    1..14
ok 2 - ListAccessKeys (empty) OK # time=57.242ms

# Subtest: CreateAccessKey OK
    ok 1 - should not error
    ok 2 - expect truthy value
    ok 3 - should be equal
    ok 4 - headers ok
    ok 5 - headers allow-origin
    ok 6 - headers allow-methods
    ok 7 - headers date
    ok 8 - headers request-id
    ok 9 - headers response time
    ok 10 - headers server
    ok 11 - headers connection
    ok 12 - headers api-version OK
    ok 13 - accesskeyid
    ok 14 - accesskeysecret
    ok 15 - access key created
    ok 16 - should be equal
    ok 17 - should not error
    ok 18 - should be equal
    ok 19 - headers ok
    ok 20 - headers allow-origin
    ok 21 - headers allow-methods
    ok 22 - headers date
    ok 23 - headers request-id
    ok 24 - headers response time
    ok 25 - headers server
    ok 26 - headers connection
    ok 27 - headers api-version OK
    ok 28 - expect truthy value
    ok 29 - expect truthy value
    ok 30 - expect truthy value
    1..30
ok 3 - CreateAccessKey OK # time=208.848ms

# Subtest: GetKey OK - other
    ok 1 - expect truthy value
    ok 2 - expect truthy value
    ok 3 - should be equal
    ok 4 - expect truthy value
    ok 5 - should be equal
    ok 6 - expect truthy value
    ok 7 - should be equal
    1..7
ok 4 - GetKey OK - other # time=51.48ms

# Subtest: DeleteAccessKey OK
    ok 1 - should not error
    ok 2 - should be equal
    ok 3 - headers ok
    ok 4 - headers allow-origin
    ok 5 - headers allow-methods
    ok 6 - headers date
    ok 7 - headers request-id
    ok 8 - headers response time
    ok 9 - headers server
    ok 10 - headers connection
    ok 11 - headers api-version OK
    1..11
ok 5 - DeleteAccessKey OK # time=105.758ms

# Subtest: DeleteAccessKey 404
    ok 1 - expect truthy value
    ok 2 - should be equal
    ok 3 - should be equal
    ok 4 - expect truthy value
    1..4
ok 6 - DeleteAccessKey 404 # time=62.524ms

# Subtest: teardown
    ok 1 - teardown success
    1..1
ok 7 - teardown # time=1537.031ms

1..7
# time=8217.602ms
#
# TESTS COMPLETE IN 9 SECONDS, SUMMARY:
#
#   PASS: 7 / 7
#
```