### PR TITLE
Add incremental argument to CreateImageFromMachine

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -3932,7 +3932,7 @@ homepage    | String   | No  | The image [homepage](https://images.joyent.com/do
 eula        | String   | No  | The image [eula](https://images.joyent.com/docs/#manifest-eula)
 acl         | String   | No  | The image [acl](https://images.joyent.com/docs/#manifest-acl)
 tags        | String   | No  | The image [tags](https://images.joyent.com/docs/#manifest-tags)
-incremental | Boolean  | No  | Whether this is an incremental image
+incremental | Boolean  | No  | Whether to create an incremental image. Default is true.
 
 ### Returns
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -880,6 +880,10 @@ Note that a `Triton-Datacenter-Name` response header was added in 9.2.0.
 
 The section describes API changes in CloudAPI versions.
 
+## 9.15.0
+
+- Add incremental argument to CreateImageFromMachine [#72](https://github.com/joyent/sdc-cloudapi/pull/72).
+
 ## 9.14.0
 
 - Expose Feed of Machines Changes [#68](https://github.com/joyent/sdc-cloudapi/pull/68).
@@ -3928,6 +3932,7 @@ homepage    | String   | No  | The image [homepage](https://images.joyent.com/do
 eula        | String   | No  | The image [eula](https://images.joyent.com/docs/#manifest-eula)
 acl         | String   | No  | The image [acl](https://images.joyent.com/docs/#manifest-acl)
 tags        | String   | No  | The image [tags](https://images.joyent.com/docs/#manifest-tags)
+incremental | Boolean  | No  | Whether this is an incremental image
 
 ### Returns
 

--- a/lib/datasets.js
+++ b/lib/datasets.js
@@ -449,6 +449,7 @@ function get(req, res, next) {
 function create(req, res, next) {
     var log = req.log;
     var action = req.params.action;
+    var incremental = (req.params.incremental !== false);
 
     if (action) {
         return next();
@@ -490,7 +491,7 @@ function create(req, res, next) {
 
     var createOpts = {
         vm_uuid: vm_uuid,
-        incremental: true,
+        incremental: incremental,
         headers: {
             'x-request-id': req.getId()
         }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "cloudapi",
     "description": "Triton CloudAPI",
-    "version": "9.14.0",
+    "version": "9.15.0",
     "author": "Joyent (joyent.com)",
     "private": true,
     "engines": {


### PR DESCRIPTION
Currently there is no way to create a full image because `CreateImageFromMachine` is hard-coded to always generate incremental images (https://github.com/joyent/sdc-cloudapi/issues/71).