### PR TITLE
joyent/sdc-cloudapi#42 cueball HTTP agent config missing pinger or TCP keepalives

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "changefeed": "1.5.2",
     "clone": "0.1.5",
     "ctype": "0.5.2",
-    "cueball": "2.1.1",
+    "cueball": "2.10.1",
     "filed": "0.0.7",
     "http-signature": "1.1.0",
     "joyent-schemas": "git+https://github.com/joyent/schemas.git#dd1c3cbfae6e2aa6ceafbe003bd95fb5e579e748",

--- a/sapi_manifests/cloudapi/template
+++ b/sapi_manifests/cloudapi/template
@@ -106,7 +106,10 @@
                 "delay": 250,
                 "maxDelay": 1000
             }
-        }
+        },
+        "tcpKeepAliveInitialDelay": 10000,
+        "ping": "/ping",
+        "pingInterval": 30000
     },
     {{#MAHI_SERVICE}}
     "mahi": {


### PR DESCRIPTION
Testing done:
 * ran `make check`
 * have been running this in production at UQ for the last ~12 months (our cloudapi has long idle periods, so were hitting these ECONNRESET issues very regularly before this)