### PR TITLE
joyent/sdc-cloudapi#82 provision_limits plugin does not enforce limits on resize

### DIFF
--- a/lib/plugin-manager.js
+++ b/lib/plugin-manager.js
@@ -384,7 +384,7 @@ function allowResize(opts, cb) {
     assert.uuid(opts.req_id, 'opts.req_id');
     assert.func(cb, 'cb');
 
-    opts.vm = { uuid: opts.vm.id };
+    opts.vm = { uuid: opts.vm.id, ram: opts.vm.memory, quota: opts.vm.disk };
 
     var hooks = this.hooks.allowResize;
     var funcs = hooks.map(function wrapFunc(func) {

--- a/plugins/provision_limits.js
+++ b/plugins/provision_limits.js
@@ -492,11 +492,11 @@ function canProvision(log, resizeVm, pkg, vms, limits) {
             limit.used += 1;
         }
 
-        if (limit.used > limit.value) {
-            log.info({ limit: limit }, 'Provision/resize limit exceeded');
-            return false;
+        if (limit.used <= limit.value) {
+            return true;
         }
-        return true;
+        log.info({ limit: limit }, 'Provision/resize limit exceeded');
+        return false;
     });
 }
 


### PR DESCRIPTION
Testing done:
 * ran `make check`
 * built an image with `make buildimage`, deployed it
 * gave an account a 1GB ram quota limit, created a VM with a 1GB package
 * tried to resize the VM to a larger package, verified that it was denied (previously succeeded)
 * tried to resize the VM to a smaller package, succeeded

We've also been running with this patch in production at UQ for about 6 months.