### PR TITLE
joyent/sdc-cloudapi#84 AddNic should accept a "primary" argument

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -12,7 +12,8 @@ markdown2extras: tables, code-friendly
 -->
 
 <!--
-    Copyright 2020 Joyent, Inc.
+    Copyright 2021 Joyent, Inc.
+    Copyright 2021 The University of Queensland
 -->
 
 
@@ -879,6 +880,10 @@ Note that a `Triton-Datacenter-Name` response header was added in 9.2.0.
 # Versions
 
 The section describes API changes in CloudAPI versions.
+
+## 9.15.0
+
+- Allow setting the `primary` option with the AddNic API [#84].
 
 ## 9.14.0
 
@@ -9796,6 +9801,7 @@ Creates a new NIC on an instance belonging to a given account.
 **Field** | **Type** | **Description**
 --------- | -------- | ---------------
 network   | Object or String   | [Network object](#network-objects) or network UUID string.
+primary   | Boolean  | Whether to make this NIC the new primary NIC
 
 ### Returns
 

--- a/lib/nics.js
+++ b/lib/nics.js
@@ -5,7 +5,8 @@
  */
 
 /*
- * Copyright 2020 Joyent, Inc.
+ * Copyright 2021 Joyent, Inc.
+ * Copyright 2021 The University of Queensland
  */
 
 /*
@@ -108,6 +109,8 @@ function addNic(req, res, next) {
     var login = req.account.login;
     var networkArg = req.params.network;
     var origin = req.params.origin || 'cloudapi';
+    var isPrimary = req.params.primary === true ||
+        req.params.primary === 'true';
     var context = {
         caller: req._auditCtx
     };
@@ -368,6 +371,7 @@ function addNic(req, res, next) {
             owner_uuid: ownerUuid,
             state: 'provisioning',
             origin: origin,
+            primary: isPrimary,
             context: context
         };
 
@@ -460,7 +464,8 @@ function addNic(req, res, next) {
             creator_uuid: ownerUuid,
             macs: [nic.mac],
             origin: origin,
-            context: context
+            context: context,
+            primary: isPrimary
         }, {
             log: log,
             headers: headers

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "cloudapi",
   "description": "Triton CloudAPI",
-  "version": "9.14.1",
+  "version": "9.15.0",
   "author": "Joyent (joyent.com)",
   "private": true,
   "engines": {


### PR DESCRIPTION
Testing done:
 * Ran `make check`
 * Hot-patched into an existing cloudapi zone, tested with modified `node-triton` with a `--primary` option to `triton inst nic create`

Haven't done a full clean build yet (will update this PR)