### PR TITLE
joyent/sdc-cloudapi#86 want support for additional "external" NIC tags

### DIFF
--- a/lib/endpoints/networks.js
+++ b/lib/endpoints/networks.js
@@ -5,7 +5,8 @@
  */
 
 /*
- * Copyright (c) 2019, Joyent, Inc.
+ * Copyright 2021 Joyent, Inc.
+ * Copyright 2021 The University of Queensland
  */
 
 var assert = require('assert-plus');
@@ -136,7 +137,7 @@ function translateErr(err) {
 
 
 // Note here "net" can be a network, fabric network or network_pool from NAPI
-function translateNetwork(net) {
+function translateNetwork(req, net) {
     assert.object(net, 'net');
 
     var obj = {
@@ -151,6 +152,11 @@ function translateNetwork(net) {
         isPublic = false;
     } else {
         isPublic = netconfig.isNetExternal(net);
+        req.config.extra_external_tags.forEach(function (tag) {
+            if (netconfig.isNetTagged(net, tag)) {
+                isPublic = true;
+            }
+        });
     }
 
     obj['public'] = isPublic;
@@ -254,7 +260,7 @@ function listNetworks(req, res, next) {
         // assuming this list never gets too big
         return skipNetworkUuids.indexOf(n.uuid) === -1;
     }).map(function (pool) {
-        return translateNetwork(pool);
+        return translateNetwork(req, pool);
     });
 
     req.log.debug({
@@ -282,7 +288,7 @@ function getNetwork(req, res, next) {
         resources.getRoleTags(req, res);
     }
 
-    network = translateNetwork(net[0]);
+    network = translateNetwork(req, net[0]);
 
     req.log.debug({
         network: network,
@@ -597,7 +603,7 @@ function updateFabricNetwork(req, res, next) {
             return;
         }
 
-        res.send(translateNetwork(network));
+        res.send(translateNetwork(req, network));
         next();
     });
 }
@@ -707,7 +713,7 @@ function listFabricNetworks(req, res, next) {
 
         res.send(networks.map(function _translateNetwork(network) {
             assert.object(network, 'network');
-            return translateNetwork(network);
+            return translateNetwork(req, network);
         }));
 
         next();
@@ -747,7 +753,7 @@ function createFabricNetwork(req, res, next) {
             return;
         }
 
-        res.send(201, translateNetwork(network));
+        res.send(201, translateNetwork(req, network));
         next();
     });
 }
@@ -774,7 +780,7 @@ function getFabricNetwork(req, res, next) {
             return;
         }
 
-        res.send(translateNetwork(network));
+        res.send(translateNetwork(req, network));
         next();
     });
 }

--- a/lib/middleware/networks.js
+++ b/lib/middleware/networks.js
@@ -5,7 +5,8 @@
  */
 
 /*
- * Copyright (c) 2019, Joyent, Inc.
+ * Copyright 2021 Joyent, Inc.
+ * Copyright 2021 The University of Queensland
  */
 
 
@@ -102,6 +103,12 @@ function loadNetworks(req, res, next) {
                 externalNetworks.push(pool.uuid);
             } else if (netconf.isNetInternal(pool) || isFabric === true) {
                 internalNetworks.push(pool.uuid);
+            } else {
+                req.config.extra_external_tags.forEach(function (tag) {
+                    if (netconf.isNetTagged(pool, tag)) {
+                        externalNetworks.push(pool.uuid);
+                    }
+                });
             }
         });
 
@@ -127,6 +134,12 @@ function loadNetworks(req, res, next) {
                     externalNetworks.push(net.uuid);
                 } else if (netconf.isNetInternal(net) || net.fabric === true) {
                     internalNetworks.push(net.uuid);
+                } else {
+                    req.config.extra_external_tags.forEach(function (tag) {
+                        if (netconf.isNetTagged(net, tag)) {
+                            externalNetworks.push(net.uuid);
+                        }
+                    });
                 }
             });
 

--- a/lib/plugin-manager.js
+++ b/lib/plugin-manager.js
@@ -5,7 +5,8 @@
  */
 
 /*
- * Copyright 2020 Joyent, Inc.
+ * Copyright 2021 Joyent, Inc.
+ * Copyright 2021 The University of Queensland
  */
 
 /*
@@ -82,6 +83,7 @@ function init(app) {
     self.api = {
         log: app.log,
         datacenterName: app.config.datacenter_name,
+        extraExternalTags: app.config.extra_external_tags,
         service: 'cloudapi',
         NotAuthorizedError: require('restify').NotAuthorizedError,
         getNapiNetworksForAccount: function getNapiShim(obj, cb) {

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "sdc-clients": "git+https://github.com/joyent/node-sdc-clients.git#01b9136799e4c76e26c59dd266cd5435cccde534",
     "semver": "5.4.1",
     "triton-metrics": "1.0.3",
-    "triton-netconfig": "1.3.0",
+    "triton-netconfig": "1.5.0",
     "ufds": "1.7.0",
     "uuid": "^8.3.0",
     "uuid-by-string": "0.6.0",

--- a/plugins/filter_owner_networks.js
+++ b/plugins/filter_owner_networks.js
@@ -5,7 +5,8 @@
  */
 
 /*
- * Copyright (c) 2019, Joyent, Inc.
+ * Copyright 2021 Joyent, Inc.
+ * Copyright 2021 The University of Queensland
  */
 
 /*
@@ -131,7 +132,13 @@ function findOwnerExternalNetwork(api, cfg) {
             });
 
             var external = owned.filter(function filterExternal(network) {
-                return (netconf.isNetExternal(network));
+                var ext = netconf.isNetExternal(network);
+                api.extraExternalTags.forEach(function (tag) {
+                    if (netconf.isNetTagged(network, tag)) {
+                        ext = true;
+                    }
+                });
+                return ext;
             });
 
             if (external.length === 0) {

--- a/sapi_manifests/cloudapi/template
+++ b/sapi_manifests/cloudapi/template
@@ -156,6 +156,13 @@
         }
     },
 
+    {{#CLOUDAPI_EXTERNAL_TAGS}}
+    "extra_external_tags": {{{CLOUDAPI_EXTERNAL_TAGS}}},
+    {{/CLOUDAPI_EXTERNAL_TAGS}}
+    {{^CLOUDAPI_EXTERNAL_TAGS}}
+    "extra_external_tags": [],
+    {{/CLOUDAPI_EXTERNAL_TAGS}}
+
     {{^account_allowed_dcs}}
     "account_allowed_dcs": false,
     {{/account_allowed_dcs}}


### PR DESCRIPTION
Testing done:
 * `make check`
 * built cloudapi image using `make buildimage`, deployed
 * set SAPI metadata `CLOUDAPI_EXTERNAL_TAGS` on the cloudapi service object
 * verified that cloudapi config was updated and restarted
 * verified that `triton network list` now shows networks on that tag as "public"
 * verified that creating a new VM without any `--network` options now includes a network from that tag

We've had this one in production at UQ since at least mid last year, and previous versions of it (not quite the same as this patch) long before that.