### PR TITLE
PORTAL-3653 Log details when an auth token is invalid.

### DIFF
--- a/lib/auth.js
+++ b/lib/auth.js
@@ -6,6 +6,7 @@
 
 /*
  * Copyright 2020 Joyent, Inc.
+ * Copyright 2023 MNX Cloud, Inc.
  */
 
 /*
@@ -328,15 +329,22 @@ function tokenAuth(req, res, next) {
             var now = new Date();
 
             if (now > expires) {
+                log.error({ expired: expires }, 'expired token');
                 return invalidCreds();
             }
         }
 
         if (obj.devkeyId !== sig.keyId) {
+            log.error({
+                devKeyId: obj.devkeyId,
+                sigKeyId: sig.keyId
+            }, 'token keyid mismatch');
             return invalidCreds();
         }
 
         if (!obj.permissions.cloudapi) {
+            log.error({ permissions: obj.permissions },
+                'missing cloudapi permissions');
             return invalidCreds();
         }
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "cloudapi",
   "description": "Triton CloudAPI",
-  "version": "9.16.1",
+  "version": "9.16.2",
   "author": "MNX Cloud (mnx.io)",
   "private": true,
   "engines": {


### PR DESCRIPTION

Installed this branch locally, sent invalid tokens to CloudAPI, and confirmed the logs:

```
[2023-04-05T20:35:08.534Z] ERROR: cloudapi/49733 on 5dfe6921-0d80-4913-b0ee-09e5acfc4615: token keyid mismatch (req_id=57c0bd26-b73d-4605-b5e1-25cbc83667e4)
    devKeyId: /!piranha/keys/c5:f0:f0:c4:43:48:05:84:fd:59:3d:f5:eb:02:33:97
    --
    sigKeyId: /piranha/keys/c5:f0:f0:c4:43:48:05:84:fd:59:3d:f5:eb:02:33:97

[2023-04-05T20:40:10.758Z] ERROR: cloudapi/49733 on 5dfe6921-0d80-4913-b0ee-09e5acfc4615: expired token (req_id=77ab2d30-2a40-464f-a280-b12747895d8d, expired=2023-04-05T20:40:06.386Z)

[2023-04-05T20:43:14.749Z] ERROR: cloudapi/49733 on 5dfe6921-0d80-4913-b0ee-09e5acfc4615: missing cloudapi permissions (req_id=d8453220-0985-4235-8a61-32463edf76e2, permissions={})
```